### PR TITLE
Update DigitalOcean image_id for Debian 8.2 x64

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ is unnecessarily verbose:
 
     size_id: 512mb
     region_id: sfo1
-    # Debian 8 64-bit has slug "debian-8-x64" and id "12778278"
-    image_id: "12778278"
+    # Debian 8 64-bit has slug "debian-8-x64" and id "14169880"
+    image_id: "14169880"
     private_networking: true
 
     api_token: "{{ digitalocean_api_token }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,8 +28,8 @@ droplet_region_id: "sfo1"
 droplet_size_id: "512mb"
 
 # Ubuntu 14.04 64-bit has slug "ubuntu-14-04-x64" and id "13089493"
-# Debian 8 64-bit has slug "debian-8-x64" and id "12778278"
-droplet_image_id: "12778278"
+# Debian 8 64-bit has slug "debian-8-x64" and id "14169880"
+droplet_image_id: "14169880"
 droplet_wait: true
 droplet_wait_timeout: "300"
 droplet_extra_wait_time: "0"


### PR DESCRIPTION
The old image_id that was encoded doesn't work/exist anymore.